### PR TITLE
Replace relative links with absolute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing to Autograder.io
 
 Contributions to Autograder.io are always welcome! Autograder.io's source code is divided across a handful of repositories, including the database and API backend, the website frontend, and several supporting libraries:
-- [autograder-server](../autograder-server): The database and API backend, written with Python + Django.
-- [autograder-sandbox](../autograder-sandbox): A Python library used for running untrusted code in a Docker container.
-- [ag-website-vue](../ag-website-vue): The website frontend, written in Typescript + Vue.
-- [ag-client-typescript](../ag-client-typescript): A client library for communicating with the API, written in Typescript.
-- [autograder-contrib](../autograder-contrib): Utilities for writing command-line applications that use the Autograder.io API.
+- [autograder-server](https://github.com/eecs-autograder/autograder-server): The database and API backend, written with Python + Django.
+- [autograder-sandbox](https://github.com/eecs-autograder/autograder-sandbox): A Python library used for running untrusted code in a Docker container.
+- [ag-website-vue]([..](https://github.com/eecs-autograder/ag-website-vue): The website frontend, written in Typescript + Vue.
+- [ag-client-typescript](https://github.com/eecs-autograder/ag-client-typescript): A client library for communicating with the API, written in Typescript.
+- [autograder-contrib](https://github.com/eecs-autograder/autograder-contrib): Utilities for writing command-line applications that use the Autograder.io API.
 
 ## How do I report a bug or request a new feature?
 In general, bug and feature requests should be made by emailing help@autograder.io or by using our [central issue tracker](https://github.com/eecs-autograder/autograder.io/issues). If a lead developer suggests that you create your issue in the issue tracker of a specific repo, then you may do so.


### PR DESCRIPTION
The relative links do not work in all locations this might be displayed in the GitHub web interface.